### PR TITLE
Add foldMRec

### DIFF
--- a/core/src/main/scala/cats/FlatMapRec.scala
+++ b/core/src/main/scala/cats/FlatMapRec.scala
@@ -1,0 +1,24 @@
+package cats
+
+import simulacrum.typeclass
+
+import cats.data.Xor
+
+/**
+ * Version of [[cats.FlatMap]] capable of stack-safe recursive `flatMap`s.
+ *
+ * Based on Phil Freeman's
+ * [[http://functorial.com/stack-safety-for-free/index.pdf Stack Safety for Free]].
+ */
+@typeclass trait FlatMapRec[F[_]] extends FlatMap[F] {
+
+  /**
+   * Keeps calling `f` until a `[[cats.data.Xor.Right Right]][B]` is returned.
+   *
+   * Implementations of this method must use constant stack space.
+   *
+   * `f` must use constant stack space. (It is OK to use a constant number of
+   * `map`s and `flatMap`s inside `f`.)
+   */
+  def tailRecM[A, B](a: A)(f: A => F[A Xor B]): F[B]
+}

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -1,5 +1,6 @@
 package cats
 
+import cats.data.Xor
 import scala.collection.mutable
 import simulacrum.typeclass
 
@@ -77,10 +78,26 @@ import simulacrum.typeclass
     foldLeft(fa, B.empty)((b, a) => B.combine(b, f(a)))
 
   /**
-   * Left associative monadic folding on `F`.
+   * Left associative monadic fold on `F`.
+   *
+   * The default implementation of this is based on `foldLeft`, and thus will
+   * always fold across the entire structure. When `G` has a `MonadRec` instance,
+   * the [[foldMRec]] variation may be preferred, as it may be able to
+   * short-circuit the fold.
    */
   def foldM[G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
     foldLeft(fa, G.pure(z))((gb, a) => G.flatMap(gb)(f(_, a)))
+
+  /**
+   * Left associative monadic fold on `F`.
+   *
+   * This is similar to [[foldM]] (and the default implementation is
+   * identical), but certain structures are able to implement this in such a
+   * way that folds can be short-circuited (not traverse the entirety of the
+   * structure), depending on the `G` result produced at a given step.
+   */
+  def foldMRec[G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+    foldM(fa, z)(f)
 
   /**
    * Traverse `F[A]` using `Applicative[G]`.
@@ -305,5 +322,13 @@ object Foldable {
     def loop(): Eval[B] =
       Eval.defer(if (it.hasNext) f(it.next, loop()) else lb)
     loop()
+  }
+
+  def iterableFoldMRec[M[_], A, B](fa: Iterable[A], z: B)(f: (B, A) => M[B])(implicit M: MonadRec[M]): M[B] = {
+    val go: ((B, Iterable[A])) => M[(B, Iterable[A]) Xor B] = { case (b, fa) =>
+      if (fa.isEmpty) M.pure(Xor.right(b))
+      else M.map(f(b, fa.head))(b1 => Xor.left((b1, fa.tail)))
+    }
+    M.tailRecM((z, fa))(go)
   }
 }

--- a/core/src/main/scala/cats/MonadRec.scala
+++ b/core/src/main/scala/cats/MonadRec.scala
@@ -1,0 +1,5 @@
+package cats
+
+import simulacrum.typeclass
+
+@typeclass trait MonadRec[F[_]] extends Monad[F] with FlatMapRec[F]

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -132,7 +132,7 @@ object OptionT extends OptionTInstances {
   def liftF[F[_], A](fa: F[A])(implicit F: Functor[F]): OptionT[F, A] = OptionT(F.map(fa)(Some(_)))
 }
 
-private[data] sealed trait OptionTInstances1 {
+private[data] sealed trait OptionTInstances2 {
   implicit def optionTFunctor[F[_]:Functor]: Functor[OptionT[F, ?]] =
     new Functor[OptionT[F, ?]] {
       override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] =
@@ -148,22 +148,41 @@ private[data] sealed trait OptionTInstances1 {
     }
 }
 
+private[data] sealed trait OptionTInstances1 extends OptionTInstances2 {
+  implicit def optionTMonad[F[_]](implicit F0: Monad[F]): Monad[OptionT[F, ?]] =
+    new OptionTMonad[F] { implicit val F = F0 }
+}
+
 private[data] sealed trait OptionTInstances extends OptionTInstances1 {
-
-  implicit def optionTMonad[F[_]](implicit F: Monad[F]): Monad[OptionT[F, ?]] =
-    new Monad[OptionT[F, ?]] {
-      def pure[A](a: A): OptionT[F, A] = OptionT.pure(a)
-
-      def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
-        fa.flatMap(f)
-
-      override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] =
-        fa.map(f)
-    }
+  implicit def optionTMonadRec[F[_]](implicit F0: MonadRec[F]): MonadRec[OptionT[F, ?]] =
+    new OptionTMonadRec[F] { implicit val F = F0 }
 
   implicit def optionTEq[F[_], A](implicit FA: Eq[F[Option[A]]]): Eq[OptionT[F, A]] =
     FA.on(_.value)
 
   implicit def optionTShow[F[_], A](implicit F: Show[F[Option[A]]]): Show[OptionT[F, A]] =
     functor.Contravariant[Show].contramap(F)(_.value)
+}
+
+private[data] trait OptionTMonad[F[_]] extends Monad[OptionT[F, ?]] {
+  implicit val F: Monad[F]
+
+  def pure[A](a: A): OptionT[F, A] = OptionT.pure(a)
+
+  def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
+    fa.flatMap(f)
+
+  override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] =
+    fa.map(f)
+}
+
+private[data] trait OptionTMonadRec[F[_]] extends MonadRec[OptionT[F, ?]] with OptionTMonad[F] {
+  implicit val F: MonadRec[F]
+
+  def tailRecM[A, B](a: A)(f: A => OptionT[F, A Xor B]): OptionT[F, B] =
+    OptionT(F.tailRecM(a)(a0 => F.map(f(a0).value){
+      case None => Xor.Right(None)
+      case Some(Xor.Left(a1)) => Xor.Left(a1)
+      case Some(Xor.Right(b)) => Xor.Right(Some(b))
+    }))
 }

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -1,6 +1,7 @@
 package cats
 package data
 
+import scala.annotation.tailrec
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
@@ -203,13 +204,19 @@ private[data] sealed abstract class XorInstances extends XorInstances1 {
         }
     }
 
-  implicit def xorInstances[A]: Traverse[A Xor ?] with MonadError[Xor[A, ?], A] =
-    new Traverse[A Xor ?] with MonadError[Xor[A, ?], A] {
+  implicit def xorInstances[A]: Traverse[A Xor ?] with MonadRec[A Xor ?] with MonadError[Xor[A, ?], A] =
+    new Traverse[A Xor ?] with MonadRec[A Xor ?] with MonadError[Xor[A, ?], A] {
       def traverse[F[_]: Applicative, B, C](fa: A Xor B)(f: B => F[C]): F[A Xor C] = fa.traverse(f)
       def foldLeft[B, C](fa: A Xor B, c: C)(f: (C, B) => C): C = fa.foldLeft(c)(f)
       def foldRight[B, C](fa: A Xor B, lc: Eval[C])(f: (B, Eval[C]) => Eval[C]): Eval[C] = fa.foldRight(lc)(f)
       def flatMap[B, C](fa: A Xor B)(f: B => A Xor C): A Xor C = fa.flatMap(f)
       def pure[B](b: B): A Xor B = Xor.right(b)
+      @tailrec def tailRecM[B, C](b: B)(f: B => A Xor (B Xor C)): A Xor C =
+        f(b) match {
+          case Xor.Left(a) => Xor.Left(a)
+          case Xor.Right(Xor.Left(b1)) => tailRecM(b1)(f)
+          case Xor.Right(Xor.Right(c)) => Xor.Right(c)
+        }
       def handleErrorWith[B](fea: Xor[A, B])(f: A => Xor[A, B]): Xor[A, B] =
         fea match {
           case Xor.Left(e) => f(e)

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -241,6 +241,11 @@ private[data] abstract class XorTInstances1 extends XorTInstances2 {
 }
 
 private[data] abstract class XorTInstances2 extends XorTInstances3 {
+  implicit def xorTMonadRec[F[_], L](implicit F0: MonadRec[F]): MonadRec[XorT[F, L, ?]] =
+    new XorTMonadRec[F, L] { implicit val F = F0 }
+}
+
+private[data] abstract class XorTInstances3 extends XorTInstances4 {
   implicit def xorTMonadError[F[_], L](implicit F: Monad[F]): MonadError[XorT[F, L, ?], L] = {
     implicit val F0 = F
     new XorTMonadError[F, L] { implicit val F = F0 }
@@ -261,7 +266,7 @@ private[data] abstract class XorTInstances2 extends XorTInstances3 {
     }
 }
 
-private[data] abstract class XorTInstances3 {
+private[data] abstract class XorTInstances4 {
   implicit def xorTFunctor[F[_], L](implicit F: Functor[F]): Functor[XorT[F, L, ?]] = {
     implicit val F0 = F
     new XorTFunctor[F, L] { implicit val F = F0 }
@@ -273,10 +278,13 @@ private[data] trait XorTFunctor[F[_], L] extends Functor[XorT[F, L, ?]] {
   override def map[A, B](fa: XorT[F, L, A])(f: A => B): XorT[F, L, B] = fa map f
 }
 
-private[data] trait XorTMonadError[F[_], L] extends MonadError[XorT[F, L, ?], L] with XorTFunctor[F, L] {
+private[data] trait XorTMonad[F[_], L] extends Monad[XorT[F, L, ?]] with XorTFunctor[F, L] {
   implicit val F: Monad[F]
   def pure[A](a: A): XorT[F, L, A] = XorT.pure[F, L, A](a)
   def flatMap[A, B](fa: XorT[F, L, A])(f: A => XorT[F, L, B]): XorT[F, L, B] = fa flatMap f
+}
+
+private[data] trait XorTMonadError[F[_], L] extends MonadError[XorT[F, L, ?], L] with XorTMonad[F, L] {
   def handleErrorWith[A](fea: XorT[F, L, A])(f: L => XorT[F, L, A]): XorT[F, L, A] =
     XorT(F.flatMap(fea.value) {
       case Xor.Left(e) => f(e).value
@@ -293,6 +301,16 @@ private[data] trait XorTMonadError[F[_], L] extends MonadError[XorT[F, L, ?], L]
     fla.recover(pf)
   override def recoverWith[A](fla: XorT[F, L, A])(pf: PartialFunction[L, XorT[F, L, A]]): XorT[F, L, A] =
     fla.recoverWith(pf)
+}
+
+private[data] trait XorTMonadRec[F[_], L] extends MonadRec[XorT[F, L, ?]] with XorTMonad[F, L] {
+  implicit val F: MonadRec[F]
+  def tailRecM[A, B](a: A)(f: A => XorT[F, L, A Xor B]): XorT[F, L, B] =
+    XorT(F.tailRecM(a)(a0 => F.map(f(a0).value){
+      case Xor.Left(l) => Xor.Right(Xor.Left(l))
+      case Xor.Right(Xor.Left(a1)) => Xor.Left(a1)
+      case Xor.Right(Xor.Right(b)) => Xor.Right(Xor.Right(b))
+    }))
 }
 
 private[data] trait XorTMonadFilter[F[_], L] extends MonadFilter[XorT[F, L, ?]] with XorTMonadError[F, L] {

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -1,3 +1,6 @@
+import scala.annotation.tailrec
+import cats.data.Xor
+
 /**
  * Symbolic aliases for various types are defined here.
  */
@@ -26,12 +29,16 @@ package object cats {
  * encodes pure unary function application.
  */
   type Id[A] = A
-  implicit val idInstances: Bimonad[Id] with Traverse[Id] =
-    new Bimonad[Id] with Traverse[Id] {
+  implicit val idInstances: Bimonad[Id] with MonadRec[Id] with Traverse[Id] =
+    new Bimonad[Id] with MonadRec[Id] with Traverse[Id] {
       def pure[A](a: A): A = a
       def extract[A](a: A): A = a
       def flatMap[A, B](a: A)(f: A => B): B = f(a)
       def coflatMap[A, B](a: A)(f: A => B): B = f(a)
+      @tailrec def tailRecM[A, B](a: A)(f: A => A Xor B): B = f(a) match {
+        case Xor.Left(a1) => tailRecM(a1)(f)
+        case Xor.Right(b) => b
+      }
       override def map[A, B](fa: A)(f: A => B): B = f(fa)
       override def ap[A, B](ff: A => B)(fa: A): B = ff(fa)
       override def flatten[A](ffa: A): A = ffa

--- a/core/src/main/scala/cats/std/either.scala
+++ b/core/src/main/scala/cats/std/either.scala
@@ -1,6 +1,9 @@
 package cats
 package std
 
+import scala.annotation.tailrec
+import cats.data.Xor
+
 trait EitherInstances extends EitherInstances1 {
   implicit val eitherBitraverse: Bitraverse[Either] =
     new Bitraverse[Either] {
@@ -23,8 +26,8 @@ trait EitherInstances extends EitherInstances1 {
         }
     }
 
-  implicit def eitherInstances[A]: Monad[Either[A, ?]] with Traverse[Either[A, ?]] =
-    new Monad[Either[A, ?]] with Traverse[Either[A, ?]] {
+  implicit def eitherInstances[A]: MonadRec[Either[A, ?]] with Traverse[Either[A, ?]] =
+    new MonadRec[Either[A, ?]] with Traverse[Either[A, ?]] {
       def pure[B](b: B): Either[A, B] = Right(b)
 
       def flatMap[B, C](fa: Either[A, B])(f: B => Either[A, C]): Either[A, C] =
@@ -32,6 +35,14 @@ trait EitherInstances extends EitherInstances1 {
 
       override def map[B, C](fa: Either[A, B])(f: B => C): Either[A, C] =
         fa.right.map(f)
+
+      @tailrec
+      def tailRecM[B, C](b: B)(f: B => Either[A, B Xor C]): Either[A, C] =
+        f(b) match {
+          case Left(a) => Left(a)
+          case Right(Xor.Left(b1)) => tailRecM(b1)(f)
+          case Right(Xor.Right(c)) => Right(c)
+        }
 
       override def map2Eval[B, C, Z](fb: Either[A, B], fc: Eval[Either[A, C]])(f: (B, C) => Z): Eval[Either[A, Z]] =
         fb match {

--- a/core/src/main/scala/cats/std/list.scala
+++ b/core/src/main/scala/cats/std/list.scala
@@ -75,6 +75,9 @@ trait ListInstances extends cats.kernel.std.ListInstances {
         fa.forall(p)
 
       override def isEmpty[A](fa: List[A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa, z)(f)
     }
 
   implicit def listShow[A:Show]: Show[List[A]] =

--- a/core/src/main/scala/cats/std/list.scala
+++ b/core/src/main/scala/cats/std/list.scala
@@ -6,10 +6,12 @@ import cats.syntax.show._
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 
+import cats.data.Xor
+
 trait ListInstances extends cats.kernel.std.ListInstances {
 
-  implicit val listInstance: Traverse[List] with MonadCombine[List] with CoflatMap[List] =
-    new Traverse[List] with MonadCombine[List] with CoflatMap[List] {
+  implicit val listInstance: Traverse[List] with MonadCombine[List] with MonadRec[List] with CoflatMap[List] =
+    new Traverse[List] with MonadCombine[List] with MonadRec[List] with CoflatMap[List] {
 
       def empty[A]: List[A] = Nil
 
@@ -25,6 +27,20 @@ trait ListInstances extends cats.kernel.std.ListInstances {
 
       override def map2[A, B, Z](fa: List[A], fb: List[B])(f: (A, B) => Z): List[Z] =
         fa.flatMap(a => fb.map(b => f(a, b)))
+
+      def tailRecM[A, B](a: A)(f: A => List[A Xor B]): List[B] = {
+        val buf = List.newBuilder[B]
+        @tailrec def go(lists: List[List[A Xor B]]): Unit = lists match {
+          case (ab :: abs) :: tail => ab match {
+            case Xor.Right(b) => buf += b; go(abs :: tail)
+            case Xor.Left(a) => go(f(a) :: abs :: tail)
+          }
+          case Nil :: tail => go(tail)
+          case Nil => ()
+        }
+        go(f(a) :: Nil)
+        buf.result
+      }
 
       def coflatMap[A, B](fa: List[A])(f: List[A] => B): List[B] = {
         @tailrec def loop(buf: ListBuffer[B], as: List[A]): List[B] =

--- a/core/src/main/scala/cats/std/map.scala
+++ b/core/src/main/scala/cats/std/map.scala
@@ -46,5 +46,8 @@ trait MapInstances extends cats.kernel.std.MapInstances {
         Foldable.iterateRight(fa.values.iterator, lb)(f)
 
       override def isEmpty[A](fa: Map[K, A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: Map[K, A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa.values, z)(f)
     }
 }

--- a/core/src/main/scala/cats/std/option.scala
+++ b/core/src/main/scala/cats/std/option.scala
@@ -1,10 +1,13 @@
 package cats
 package std
 
+import scala.annotation.tailrec
+import cats.data.Xor
+
 trait OptionInstances extends cats.kernel.std.OptionInstances {
 
-  implicit val optionInstance: Traverse[Option] with MonadError[Option, Unit] with MonadCombine[Option] with CoflatMap[Option] with Alternative[Option] =
-    new Traverse[Option] with MonadError[Option, Unit]  with MonadCombine[Option] with CoflatMap[Option] with Alternative[Option] {
+  implicit val optionInstance: Traverse[Option] with MonadError[Option, Unit] with MonadCombine[Option] with MonadRec[Option] with CoflatMap[Option] with Alternative[Option] =
+    new Traverse[Option] with MonadError[Option, Unit]  with MonadCombine[Option] with MonadRec[Option] with CoflatMap[Option] with Alternative[Option] {
 
       def empty[A]: Option[A] = None
 
@@ -17,6 +20,14 @@ trait OptionInstances extends cats.kernel.std.OptionInstances {
 
       def flatMap[A, B](fa: Option[A])(f: A => Option[B]): Option[B] =
         fa.flatMap(f)
+
+      @tailrec
+      def tailRecM[A, B](a: A)(f: A => Option[A Xor B]): Option[B] =
+        f(a) match {
+          case None => None
+          case Some(Xor.Left(a1)) => tailRecM(a1)(f)
+          case Some(Xor.Right(b)) => Some(b)
+        }
 
       override def map2[A, B, Z](fa: Option[A], fb: Option[B])(f: (A, B) => Z): Option[Z] =
         fa.flatMap(a => fb.map(b => f(a, b)))

--- a/core/src/main/scala/cats/std/set.scala
+++ b/core/src/main/scala/cats/std/set.scala
@@ -25,6 +25,11 @@ trait SetInstances extends cats.kernel.std.SetInstances {
         fa.forall(p)
 
       override def isEmpty[A](fa: Set[A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        // Repeatedly calling .tail on a large set is really slow, so we
+        // convert to a stream first.
+        Foldable.iterableFoldMRec(fa.toStream, z)(f)
     }
 
   implicit def setShow[A:Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/core/src/main/scala/cats/std/stream.scala
+++ b/core/src/main/scala/cats/std/stream.scala
@@ -53,6 +53,9 @@ trait StreamInstances extends cats.kernel.std.StreamInstances {
         fa.forall(p)
 
       override def isEmpty[A](fa: Stream[A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa, z)(f)
     }
 
   implicit def streamShow[A: Show]: Show[Stream[A]] =

--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -53,6 +53,9 @@ trait VectorInstances extends cats.kernel.std.VectorInstances {
         fa.exists(p)
 
       override def isEmpty[A](fa: Vector[A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa, z)(f)
     }
 
   implicit def vectorShow[A:Show]: Show[Vector[A]] =

--- a/laws/src/main/scala/cats/laws/FlatMapRecLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapRecLaws.scala
@@ -1,0 +1,26 @@
+package cats
+package laws
+
+import cats.data.Xor
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+/**
+ * Laws that must be obeyed by any `FlatMapRec`.
+ */
+trait FlatMapRecLaws[F[_]] extends FlatMapLaws[F] {
+  implicit override def F: FlatMapRec[F]
+
+  def tailRecMConsistentFlatMap[A](a: A, f: A => F[A]): IsEq[F[A]] = {
+    val bounce = F.tailRecM[(A, Int), A]((a, 1)) { case (a0, i) =>
+      if(i > 0) f(a0).map(a1 => Xor.left((a1, i-1)))
+      else f(a0).map(Xor.right)
+    }
+    bounce <-> f(a).flatMap(f)
+  }
+}
+
+object FlatMapRecLaws {
+  def apply[F[_]](implicit ev: FlatMapRec[F]): FlatMapRecLaws[F] =
+    new FlatMapRecLaws[F] { def F: FlatMapRec[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/MonadRecLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadRecLaws.scala
@@ -1,0 +1,14 @@
+package cats
+package laws
+
+/**
+ * Laws that must be obeyed by any `MonadRec`.
+ */
+trait MonadRecLaws[F[_]] extends MonadLaws[F] with FlatMapRecLaws[F] {
+  implicit override def F: MonadRec[F]
+}
+
+object MonadRecLaws {
+  def apply[F[_]](implicit ev: MonadRec[F]): MonadRecLaws[F] =
+    new MonadRecLaws[F] { def F: MonadRec[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapRecTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapRecTests.scala
@@ -1,0 +1,35 @@
+package cats
+package laws
+package discipline
+
+import cats.laws.discipline.CartesianTests.Isomorphisms
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import Prop._
+
+trait FlatMapRecTests[F[_]] extends FlatMapTests[F] {
+  def laws: FlatMapRecLaws[F]
+
+  def flatMapRec[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFBtoC: Arbitrary[F[B => C]],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFABC: Eq[F[(A, B, C)]],
+    iso: Isomorphisms[F]
+  ): RuleSet = {
+    new DefaultRuleSet(
+      name = "flatMapRec",
+      parent = Some(flatMap[A, B, C]),
+      "tailRecM consistent flatMap" -> forAll(laws.tailRecMConsistentFlatMap[A] _))
+  }
+}
+
+object FlatMapRecTests {
+  def apply[F[_]: FlatMapRec]: FlatMapRecTests[F] =
+    new FlatMapRecTests[F] { def laws: FlatMapRecLaws[F] = FlatMapRecLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/MonadRecTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadRecTests.scala
@@ -1,0 +1,38 @@
+package cats
+package laws
+package discipline
+
+import cats.laws.discipline.CartesianTests.Isomorphisms
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+
+trait MonadRecTests[F[_]] extends MonadTests[F] with FlatMapRecTests[F] {
+  def laws: MonadRecLaws[F]
+
+  def monadRec[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFBtoC: Arbitrary[F[B => C]],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFABC: Eq[F[(A, B, C)]],
+    iso: Isomorphisms[F]
+  ): RuleSet = {
+    new RuleSet {
+      def name: String = "monadRec"
+      def bases: Seq[(String, RuleSet)] = Nil
+      def parents: Seq[RuleSet] = Seq(monad[A, B, C], flatMapRec[A, B, C])
+      def props: Seq[(String, Prop)] = Nil
+    }
+  }
+}
+
+object MonadRecTests {
+  def apply[F[_]: MonadRec]: MonadRecTests[F] =
+    new MonadRecTests[F] {
+      def laws: MonadRecLaws[F] = MonadRecLaws[F]
+    }
+}

--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.laws.discipline.{BitraverseTests, TraverseTests, MonadTests, SerializableTests, CartesianTests}
+import cats.laws.discipline.{BitraverseTests, TraverseTests, MonadRecTests, SerializableTests, CartesianTests}
 import cats.kernel.laws.OrderLaws
 
 class EitherTests extends CatsSuite {
@@ -11,8 +11,8 @@ class EitherTests extends CatsSuite {
   checkAll("Either[Int, Int]", CartesianTests[Either[Int, ?]].cartesian[Int, Int, Int])
   checkAll("Cartesian[Either[Int, ?]]", SerializableTests.serializable(Cartesian[Either[Int, ?]]))
 
-  checkAll("Either[Int, Int]", MonadTests[Either[Int, ?]].monad[Int, Int, Int])
-  checkAll("Monad[Either[Int, ?]]", SerializableTests.serializable(Monad[Either[Int, ?]]))
+  checkAll("Either[Int, Int]", MonadRecTests[Either[Int, ?]].monadRec[Int, Int, Int])
+  checkAll("MonadRec[Either[Int, ?]]", SerializableTests.serializable(MonadRec[Either[Int, ?]]))
 
   checkAll("Either[Int, Int] with Option", TraverseTests[Either[Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Either[Int, ?]", SerializableTests.serializable(Traverse[Either[Int, ?]]))

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -78,14 +78,36 @@ class FoldableTestsAdditional extends CatsSuite {
     larger.value should === (large.map(_ + 1))
   }
 
-  test("Foldable[List].foldM stack safety") {
-    def nonzero(acc: Long, x: Long): Option[Long] =
+  def checkFoldMStackSafety[F[_]](fromRange: Range => F[Int])(implicit F: Foldable[F]): Unit = {
+    def nonzero(acc: Long, x: Int): Option[Long] =
       if (x == 0) None else Some(acc + x)
 
-    val n = 100000L
-    val expected = n*(n+1)/2
-    val actual = Foldable[List].foldM((1L to n).toList, 0L)(nonzero)
-    assert(actual.get == expected)
+    val n = 100000
+    val expected = n.toLong*(n.toLong+1)/2
+    val foldMResult = F.foldM(fromRange(1 to n), 0L)(nonzero)
+    assert(foldMResult.get == expected)
+    val foldMRecResult = F.foldMRec(fromRange(1 to n), 0L)(nonzero)
+    assert(foldMRecResult.get == expected)
+  }
+
+  test("Foldable[List].foldM stack safety") {
+    checkFoldMStackSafety[List](_.toList)
+  }
+
+  test("Foldable[Stream].foldM stack safety") {
+    checkFoldMStackSafety[Stream](_.toStream)
+  }
+
+  test("Foldable[Vector].foldM stack safety") {
+    checkFoldMStackSafety[Vector](_.toVector)
+  }
+
+  test("Foldable[Set].foldM stack safety") {
+    checkFoldMStackSafety[Set](_.toSet)
+  }
+
+  test("Foldable[Map[String, ?]].foldM stack safety") {
+    checkFoldMStackSafety[Map[String, ?]](_.map(x => x.toString -> x).toMap)
   }
 
   test("Foldable[Stream]") {
@@ -112,6 +134,9 @@ class FoldableTestsAdditional extends CatsSuite {
     // test trampolining
     val large = Stream((1 to 10000): _*)
     assert(contains(large, 10000).value)
+
+    // test laziness of foldMRec
+    dangerous.foldMRec(0)((acc, a) => if (a < 2) Some(acc + a) else None) should === (None)
   }
 }
 

--- a/tests/src/test/scala/cats/tests/IdTests.scala
+++ b/tests/src/test/scala/cats/tests/IdTests.scala
@@ -9,6 +9,9 @@ class IdTests extends CatsSuite {
   checkAll("Id[Int]", BimonadTests[Id].bimonad[Int, Int, Int])
   checkAll("Bimonad[Id]", SerializableTests.serializable(Bimonad[Id]))
 
+  checkAll("Id[Int]", MonadRecTests[Id].monadRec[Int, Int, Int])
+  checkAll("MonadRec[Id]", SerializableTests.serializable(MonadRec[Id]))
+
   checkAll("Id[Int]", TraverseTests[Id].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Id]", SerializableTests.serializable(Traverse[Id]))
 }

--- a/tests/src/test/scala/cats/tests/MonadRecInstancesTests.scala
+++ b/tests/src/test/scala/cats/tests/MonadRecInstancesTests.scala
@@ -1,0 +1,41 @@
+package cats
+package tests
+
+import cats.data.{OptionT, Xor, XorT}
+
+class MonadRecInstancesTests extends CatsSuite {
+  def tailRecMStackSafety[M[_]](implicit M: MonadRec[M], Eq: Eq[M[Int]]): Unit = {
+    val n = 50000
+    val res = M.tailRecM(0)(i => M.pure(if(i < n) Xor.Left(i + 1) else Xor.Right(i)))
+    res should === (M.pure(n))
+  }
+
+  test("tailRecM stack-safety for Id") {
+    tailRecMStackSafety[Id]
+  }
+
+  test("tailRecM stack-safety for Option") {
+    tailRecMStackSafety[Option]
+  }
+
+  test("tailRecM stack-safety for OptionT") {
+    tailRecMStackSafety[OptionT[Option, ?]]
+  }
+
+  test("tailRecM stack-safety for Either") {
+    tailRecMStackSafety[Either[String, ?]]
+  }
+
+  test("tailRecM stack-safety for Xor") {
+    tailRecMStackSafety[String Xor ?]
+  }
+
+  test("tailRecM stack-safety for XorT") {
+    tailRecMStackSafety[XorT[Option, String, ?]]
+  }
+
+  test("tailRecM stack-safety for List") {
+    tailRecMStackSafety[List]
+  }
+
+}

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -1,8 +1,8 @@
 package cats.tests
 
-import cats.{Id, Monad, Cartesian, Show}
+import cats.{Id, MonadRec, Cartesian, Show}
 import cats.data.{OptionT, Xor}
-import cats.laws.discipline.{FunctorTests, SerializableTests, CartesianTests, MonadTests}
+import cats.laws.discipline.{FunctorTests, SerializableTests, CartesianTests, MonadRecTests}
 import cats.laws.discipline.arbitrary._
 
 class OptionTTests extends CatsSuite {
@@ -160,8 +160,8 @@ class OptionTTests extends CatsSuite {
     }
   }
 
-  checkAll("Monad[OptionT[List, Int]]", MonadTests[OptionT[List, ?]].monad[Int, Int, Int])
-  checkAll("Monad[OptionT[List, ?]]", SerializableTests.serializable(Monad[OptionT[List, ?]]))
+  checkAll("OptionT[List, Int]", MonadRecTests[OptionT[List, ?]].monadRec[Int, Int, Int])
+  checkAll("MonadRec[OptionT[List, ?]]", SerializableTests.serializable(MonadRec[OptionT[List, ?]]))
 
   {
     implicit val F = ListWrapper.functor

--- a/tests/src/test/scala/cats/tests/OptionTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTests.scala
@@ -14,6 +14,9 @@ class OptionTests extends CatsSuite {
   checkAll("Option[Int]", MonadCombineTests[Option].monadCombine[Int, Int, Int])
   checkAll("MonadCombine[Option]", SerializableTests.serializable(MonadCombine[Option]))
 
+  checkAll("Option[Int]", MonadRecTests[Option].monadRec[Int, Int, Int])
+  checkAll("MonadRec[Option]", SerializableTests.serializable(MonadRec[Option]))
+
   checkAll("Option[Int] with Option", TraverseTests[Option].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Option]", SerializableTests.serializable(Traverse[Option]))
 

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -13,6 +13,8 @@ class XorTTests extends CatsSuite {
   implicit val iso = CartesianTests.Isomorphisms.invariant[XorT[List, String, ?]]
   checkAll("XorT[List, String, Int]", MonadErrorTests[XorT[List, String, ?], String].monadError[Int, Int, Int])
   checkAll("MonadError[XorT[List, ?, ?]]", SerializableTests.serializable(MonadError[XorT[List, String, ?], String]))
+  checkAll("XorT[List, String, Int]", MonadRecTests[XorT[List, String, ?]].monadRec[Int, Int, Int])
+  checkAll("MonadRec[XorT[List, String, ?]]", SerializableTests.serializable(MonadRec[XorT[List, String, ?]]))
   checkAll("XorT[List, ?, ?]", BifunctorTests[XorT[List, ?, ?]].bifunctor[Int, Int, Int, String, String, String])
   checkAll("Bifunctor[XorT[List, ?, ?]]", SerializableTests.serializable(Bifunctor[XorT[List, ?, ?]]))
   checkAll("XorT[List, ?, ?]", BitraverseTests[XorT[List, ?, ?]].bitraverse[Option, Int, Int, Int, String, String, String])

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -5,7 +5,7 @@ import cats.data.{NonEmptyList, Xor, XorT}
 import cats.data.Xor._
 import cats.laws.discipline.{SemigroupKTests}
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{BitraverseTests, TraverseTests, MonadErrorTests, SerializableTests, CartesianTests}
+import cats.laws.discipline.{BitraverseTests, TraverseTests, MonadErrorTests, MonadRecTests, SerializableTests, CartesianTests}
 import cats.kernel.laws.{GroupLaws, OrderLaws}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
@@ -26,6 +26,9 @@ class XorTests extends CatsSuite {
 
   checkAll("Xor[String, Int]", MonadErrorTests[Xor[String, ?], String].monadError[Int, Int, Int])
   checkAll("MonadError[Xor, String]", SerializableTests.serializable(MonadError[Xor[String, ?], String]))
+
+  checkAll("Xor[String, Int]", MonadRecTests[Xor[String, ?]].monadRec[Int, Int, Int])
+  checkAll("MonadRec[Xor[String, ?]]", SerializableTests.serializable(MonadRec[Xor[String, ?]]))
 
   checkAll("Xor[String, Int] with Option", TraverseTests[Xor[String, ?]].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Xor[String,?]]", SerializableTests.serializable(Traverse[Xor[String, ?]]))


### PR DESCRIPTION
Resolves #1030, though it may be desirable change the default
implementation to be lazy in the future. This can be done with `FreeT`
but as of now I'm not sure how to do it without.

@TomasMikula I thought that it might be nice to add some actual usage of `MonadRec` to justify it being a good addition to cats. If you'd prefer to merge your PR without this I can always submit it to cats myself later.
